### PR TITLE
Fix unused vars and imports in training scripts

### DIFF
--- a/train.py
+++ b/train.py
@@ -2,13 +2,14 @@
 #train.py
 from __future__ import annotations
 import argparse
-import datetime, json, random, os
-from tqdm import tqdm
-from src.models.tcn import *
-from src.models.inception import *
+import datetime
+import json
+import random
+from src.models.tcn import TCNClassifier
+from src.models.inception import InceptionTimeSE
 
 from src.datasets import ECGWindowDataset, collate_fn
-from src.utils import  train_one_epoch, evaluate, FocalLoss
+from src.utils import train_one_epoch, evaluate, FocalLoss
 from pathlib import Path
 import numpy as np
 import csv

--- a/train_gru.py
+++ b/train_gru.py
@@ -3,7 +3,7 @@ import argparse
 import numpy as np
 import torch
 import torch.nn as nn
-from torch.utils.data import Dataset, DataLoader, random_split
+from torch.utils.data import Dataset, DataLoader
 from src.models.transformer import TransformerSequenceModel
 from pathlib import Path
 import csv
@@ -19,7 +19,9 @@ class EmbeddingSequenceDataset(Dataset):
         self.embeddings = np.load(embeddings_path)  # shape (N_windows, D)
         self.labels = np.load(labels_path)          # shape (N_windows,)
         if self.embeddings.shape[0] != self.labels.shape[0]:
-            raise ValueError("Embeddings and labels must have same first dimension.")
+            raise ValueError(
+                "Embeddings and labels must have same first dimension."
+            )
         self.seq_len = seq_len
         total_windows = self.embeddings.shape[0]
         # Drop remainder so that total_windows % seq_len == 0
@@ -27,8 +29,10 @@ class EmbeddingSequenceDataset(Dataset):
         self.embeddings = self.embeddings[:usable]
         self.labels = self.labels[:usable]
 
-        # Now reshape: (num_seqs, seq_len, D), and (num_seqs, seq_len)
-        self.embeddings = self.embeddings.reshape(-1, seq_len, self.embeddings.shape[1])
+        # Now reshape: (num_seqs, seq_len, D) and (num_seqs, seq_len)
+        self.embeddings = self.embeddings.reshape(
+            -1, seq_len, self.embeddings.shape[1]
+        )
         self.labels = self.labels.reshape(-1, seq_len)
 
     def __len__(self):
@@ -216,7 +220,6 @@ def main(args):
     )
 
     # --- Prepare logging ---
-    run_tag = Path(args.out_dir).name  # just the name of directory for naming
     out_dir = Path(args.out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
     metrics_path = out_dir / "gru_metrics.csv"

--- a/train_hierarchical.py
+++ b/train_hierarchical.py
@@ -5,7 +5,7 @@ import torch
 from torch.utils.data import Dataset, DataLoader
 from src.models.inception import InceptionTimeSE, HierarchicalSeizureModel
 from src.models.transformer import TransformerSequenceModel
-from src.utils import train_one_epoch, evaluate, FocalLoss
+from src.utils import train_one_epoch, evaluate
 
 class WindowSequenceDataset(Dataset):
     """Create sequences of windows directly from NPZ."""
@@ -35,15 +35,6 @@ def build_model(args):
         kernel_sizes=args.kernel_sizes,
         use_se=not args.no_se,
     )
-    if args.seq_model == "transformer":
-        seq_model = TransformerSequenceModel(
-            input_dim=window_encoder.embedding_dim,
-            num_heads=args.num_heads,
-            hidden_dim=args.hidden_dim,
-            num_layers=args.num_layers,
-        )
-    else:
-        seq_model = "gru"
     model = HierarchicalSeizureModel(
         window_encoder=window_encoder,
         hidden_size=args.hidden_size,


### PR DESCRIPTION
## Summary
- cleanup imports in train.py
- remove unused variable in train_gru.py
- drop unused import and variable in train_hierarchical.py

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8 train.py train_hierarchical.py train_gru.py`
- `python train.py --help` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6842114e055883338365c1c62b438bda