### PR TITLE
Improve training script and focal loss

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -15,6 +15,8 @@ from collections import defaultdict
 import random
 
 class FocalLoss(nn.Module):
+    """Binary focal loss with optional positive class weighting."""
+
     def __init__(self, alpha: float = 1.0, gamma: float = 2.0):
         super().__init__()
         self.alpha = alpha
@@ -23,9 +25,11 @@ class FocalLoss(nn.Module):
 
     def forward(self, logits: torch.Tensor, targets: torch.Tensor) -> torch.Tensor:
         bce_loss = self.bce(logits, targets)
-        prob_t = torch.exp(-bce_loss)
-        focal_term = (1.0 - prob_t) ** self.gamma
-        loss = self.alpha * focal_term * bce_loss
+        probs = torch.sigmoid(logits)
+        p_t = probs * targets + (1 - probs) * (1 - targets)
+        alpha_factor = self.alpha * targets + (1 - targets)
+        focal_weight = alpha_factor * (1 - p_t) ** self.gamma
+        loss = focal_weight * bce_loss
         return loss.mean()
 
 

--- a/train_hierarchical.py
+++ b/train_hierarchical.py
@@ -122,8 +122,8 @@ def evaluate(model, loader, criterion, device):
 
 def main(args):
     device = (
-        torch.device("mps") if torch.backends.mps.is_available() else
         torch.device("cuda") if torch.cuda.is_available() else
+        torch.device("mps") if torch.backends.mps.is_available() else
         torch.device("cpu")
     )
     set_seed(args.seed)
@@ -261,7 +261,7 @@ if __name__ == "__main__":
     p.add_argument("--out_channels", type=int, default=32)
     p.add_argument("--bottleneck_channels", type=int, default=32)
     p.add_argument("--kernel_sizes", type=int, nargs="+", default=[9, 19, 39])
-    p.add_argument("--use_se", action="store_true", help="Disable SE blocks")
+    p.add_argument("--use_se", action="store_true", help="Enable SE blocks")
     p.add_argument("--hidden_size", type=int, default=64)
     p.add_argument("--num_layers", type=int, default=2)
     p.add_argument("--seq_model", choices=["gru", "lstm", "transformer"], default="gru")


### PR DESCRIPTION
## Summary
- refine FocalLoss to apply class weighting only to positives
- prefer CUDA over MPS in training script
- clarify `--use_se` help text

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6865a479d9808333a95ea2eec8a3f9a1