### PR TITLE
Add training visualization notebook

### DIFF
--- a/notebooks/training_analysis.ipynb
+++ b/notebooks/training_analysis.ipynb
@@ -1,0 +1,174 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "65e8afaa",
+   "metadata": {},
+   "source": [
+    "# Training Analysis and Visualization\n",
+    "\n",
+    "This notebook demonstrates how to visualize ECG samples and analyze the training metrics produced by the training scripts."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "929018b2",
+   "metadata": {},
+   "source": [
+    "## Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aa5ba6bc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "from pathlib import Path\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3c7955ab",
+   "metadata": {},
+   "source": [
+    "## Visualizing raw ECG data\n",
+    "Specify the path to one of your raw ECG `.csv` files. Each file should contain at least the columns `Time [s]`, `Signal [mV]` and `Seizure [bool]`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0b212a07",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "csv_path = Path('../data/raw_ecg/example.csv')  # change to your file\n",
+    "\n",
+    "if csv_path.exists():\n",
+    "    df = pd.read_csv(csv_path)\n",
+    "    fig, ax = plt.subplots(figsize=(10, 3))\n",
+    "    ax.plot(df['Time [s]'], df['Signal [mV]'], label='ECG')\n",
+    "    if 'Seizure [bool]' in df.columns:\n",
+    "        ax.fill_between(df['Time [s]'], df['Signal [mV]'].min(), df['Signal [mV]'].max(),\n",
+    "                         where=df['Seizure [bool]'].astype(bool), color='red', alpha=0.2, label='Seizure')\n",
+    "    ax.set_xlabel('Time [s]')\n",
+    "    ax.set_ylabel('Amplitude [mV]')\n",
+    "    ax.legend()\n",
+    "    plt.show()\n",
+    "else:\n",
+    "    print(f'File {csv_path} not found. Please update the path above.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7ccc63f6",
+   "metadata": {},
+   "source": [
+    "## Loading training metrics\n",
+    "After running `train_hierarchical.py` or `train_hybrid_pipeline.py`, a `metrics.csv` file is stored in the run directory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ddb91319",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "metrics_path = Path('../runs/example_run/metrics.csv')  # update with your run\n",
+    "\n",
+    "metrics = pd.read_csv(metrics_path) if metrics_path.exists() else pd.DataFrame()\n",
+    "metrics.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f1d4eb5a",
+   "metadata": {},
+   "source": [
+    "## Convergence curves"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bca1ad31",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if not metrics.empty:\n",
+    "    fig, ax = plt.subplots(figsize=(6,4))\n",
+    "    ax.plot(metrics['epoch'], metrics['train_loss'], label='train loss')\n",
+    "    ax.plot(metrics['epoch'], metrics['val_loss'], label='val loss')\n",
+    "    ax.set_xlabel('Epoch')\n",
+    "    ax.set_ylabel('Loss')\n",
+    "    ax.legend()\n",
+    "    plt.show()\n",
+    "else:\n",
+    "    print('Metrics dataframe is empty. Make sure metrics_path points to a valid CSV.')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "555bc095",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if not metrics.empty:\n",
+    "    fig, ax = plt.subplots(figsize=(6,4))\n",
+    "    ax.plot(metrics['epoch'], metrics['auroc'], label='AUROC')\n",
+    "    ax.plot(metrics['epoch'], metrics['auprc'], label='AUPRC')\n",
+    "    ax.set_xlabel('Epoch')\n",
+    "    ax.set_ylabel('Score')\n",
+    "    ax.legend()\n",
+    "    plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7e20eb16",
+   "metadata": {},
+   "source": [
+    "## Confusion matrix for the test set"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "107ec4c3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "if not metrics.empty and 'TEST' in metrics['epoch'].values:\n",
+    "    test_row = metrics[metrics['epoch'] == 'TEST'].iloc[0]\n",
+    "    cm = np.array([[test_row['tn'], test_row['fp']],\n",
+    "                   [test_row['fn'], test_row['tp']]])\n",
+    "    fig, ax = plt.subplots()\n",
+    "    im = ax.imshow(cm, cmap='Blues')\n",
+    "    ax.set_xticks([0,1]); ax.set_yticks([0,1])\n",
+    "    ax.set_xticklabels(['Negative','Positive'])\n",
+    "    ax.set_yticklabels(['Negative','Positive'])\n",
+    "    for i in range(2):\n",
+    "        for j in range(2):\n",
+    "            ax.text(j, i, int(cm[i, j]), ha='center', va='center', color='black')\n",
+    "    ax.set_xlabel('Predicted label')\n",
+    "    ax.set_ylabel('True label')\n",
+    "    ax.set_title('Confusion Matrix')\n",
+    "    plt.show()\n",
+    "else:\n",
+    "    print('Test metrics not found in metrics.csv.')"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add `training_analysis.ipynb` with examples to load ECG data and visualize training metrics

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686758eaf41c83338f912aa84f75922b